### PR TITLE
Video Playback Improvements

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/metascan/core/media.py
+++ b/metascan/core/media.py
@@ -46,6 +46,8 @@ class Media:
 
     is_favorite: bool = False
 
+    playback_speed: Optional[float] = None  # Per-file playback speed, None uses default
+
     thumbnail_path: Optional[Path] = field(
         default=None,
         metadata=config(

--- a/metascan/ui/main_window.py
+++ b/metascan/ui/main_window.py
@@ -349,8 +349,8 @@ class MainWindow(QMainWindow):
         self.upscale_queue_window = None
 
         # Create media viewer (initially hidden)
-        self.media_viewer = (
-            MediaViewer()
+        self.media_viewer = MediaViewer(
+            db_manager=self.db_manager
         )  # Create without parent to control positioning
         self.media_viewer.setWindowFlags(
             Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint
@@ -1306,6 +1306,8 @@ class MainWindow(QMainWindow):
             self.all_media = self.db_manager.get_all_media()
             # Load favorite status from database
             self.db_manager.load_favorite_status(self.all_media)
+            # Load playback speeds from database
+            self.db_manager.load_playback_speed(self.all_media)
             # Apply current sorting
             self._apply_sorting()
             print(f"Loaded {len(self.all_media)} media items")

--- a/metascan/ui/media_viewer.py
+++ b/metascan/ui/media_viewer.py
@@ -306,11 +306,13 @@ class VideoPlayer(QWidget):
         # Frame-by-frame navigation buttons
         self.prev_frame_button = QPushButton("◀◀")
         self.prev_frame_button.setFixedSize(40, 30)
+        self.prev_frame_button.setStyleSheet("padding: 2px;")
         self.prev_frame_button.clicked.connect(self.previous_frame)
         self.prev_frame_button.setToolTip("Previous Frame (,)")
 
         self.next_frame_button = QPushButton("▶▶")
         self.next_frame_button.setFixedSize(40, 30)
+        self.next_frame_button.setStyleSheet("padding: 2px;")
         self.next_frame_button.clicked.connect(self.next_frame)
         self.next_frame_button.setToolTip("Next Frame (.)")
 
@@ -376,12 +378,12 @@ class VideoPlayer(QWidget):
         control_layout.addWidget(self.volume_slider)
         control_layout.addWidget(self.shortcuts_button)
 
-        control_widget = QWidget()
-        control_widget.setStyleSheet("background-color: rgba(0, 0, 0, 200);")
-        control_widget.setLayout(control_layout)
-        control_widget.setFixedHeight(50)
+        self.control_widget = QWidget()
+        self.control_widget.setStyleSheet("background-color: rgba(0, 0, 0, 200);")
+        self.control_widget.setLayout(control_layout)
+        self.control_widget.setFixedHeight(50)
 
-        layout.addWidget(control_widget)
+        layout.addWidget(self.control_widget)
 
         # Connect media player signals
         self.media_player.positionChanged.connect(self.update_position)

--- a/metascan/ui/slideshow_viewer.py
+++ b/metascan/ui/slideshow_viewer.py
@@ -1,0 +1,567 @@
+"""
+Slideshow viewer for displaying media files in automatic slideshow mode.
+Separate implementation from MediaViewer to avoid conditional logic.
+"""
+
+import random
+from typing import List, Optional
+from pathlib import Path
+
+from PyQt6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QStackedWidget,
+    QRadioButton,
+    QComboBox,
+    QButtonGroup,
+    QFrame,
+)
+from PyQt6.QtCore import Qt, pyqtSignal, QTimer, QPoint, QCoreApplication
+from PyQt6.QtGui import QKeyEvent, QMouseEvent, QCursor, QCloseEvent
+
+from metascan.core.media import Media
+from metascan.core.database_sqlite import DatabaseManager
+from metascan.ui.media_viewer import ImageViewer, VideoPlayer
+
+
+class SlideshowViewer(QWidget):
+    """Full-screen slideshow viewer with auto-advance and shuffle support."""
+
+    # Signals
+    closed = pyqtSignal()
+    media_changed = pyqtSignal(Media)
+    favorite_toggled = pyqtSignal(Media, bool)  # Emits Media object, not Path
+    delete_requested = pyqtSignal(Media)
+
+    def __init__(self, db_manager: DatabaseManager, parent=None):
+        super().__init__(parent)
+        self.db_manager = db_manager
+
+        # Media list and navigation state
+        self.media_list: List[Media] = []
+        self.current_index = 0
+        self.shuffled_indices: List[int] = []
+        self.shuffle_position = 0
+
+        # Slideshow state
+        self.is_running = False
+        self.is_paused = False
+        self.view_mode = "ordered"  # "ordered" or "random"
+        self.slide_duration = 5000  # milliseconds (default 5s)
+
+        # Timers
+        self.advance_timer = QTimer(self)
+        self.advance_timer.timeout.connect(self._advance_to_next)
+        self.ui_hide_timer = QTimer(self)
+        self.ui_hide_timer.timeout.connect(self._hide_ui)
+        self.ui_hide_timer.setSingleShot(True)
+
+        # UI components (initialized in _init_ui)
+        self.image_viewer: ImageViewer
+        self.video_player: Optional[VideoPlayer] = None  # Created on demand
+        self.video_player_index: int = -1  # Track video player index in stacked widget
+        self.stacked_widget: QStackedWidget
+        self.setup_panel: QFrame
+        self.start_button: QPushButton
+        self.ordered_radio: QRadioButton
+        self.random_radio: QRadioButton
+        self.mode_button_group: QButtonGroup
+        self.timing_combo: QComboBox
+
+        self._init_ui()
+        self._setup_window()
+
+    def _setup_window(self):
+        """Configure window properties."""
+        self.setWindowTitle("Slideshow")
+        self.setStyleSheet("background-color: black;")
+        self.setMouseTracking(True)
+
+    def _init_ui(self):
+        """Initialize the UI components."""
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.setSpacing(0)
+
+        # Create stacked widget for image/video switching
+        self.stacked_widget = QStackedWidget()
+        self.stacked_widget.setStyleSheet("background-color: black;")
+
+        # Create image viewer
+        self.image_viewer = ImageViewer()
+        self.stacked_widget.addWidget(self.image_viewer)
+
+        # Video player will be created on demand to avoid state issues
+
+        # Add stacked widget to main layout
+        main_layout.addWidget(self.stacked_widget)
+
+        # Create setup panel at the bottom (not overlaid)
+        self.setup_panel = self._create_setup_panel()
+        main_layout.addWidget(self.setup_panel)
+
+        self.setLayout(main_layout)
+
+    def _create_setup_panel(self) -> QFrame:
+        """Create the setup panel at the bottom with Start button and controls."""
+        panel = QFrame()
+        panel.setStyleSheet(
+            """
+            QFrame {
+                background-color: rgba(0, 0, 0, 180);
+            }
+            QLabel {
+                color: white;
+                font-size: 16px;
+                font-weight: bold;
+            }
+            QPushButton {
+                background-color: #2196F3;
+                color: white;
+                border: none;
+                border-radius: 5px;
+                padding: 12px 30px;
+                font-size: 16px;
+                font-weight: bold;
+            }
+            QPushButton:hover {
+                background-color: #1976D2;
+            }
+            QRadioButton {
+                color: white;
+                font-size: 14px;
+                spacing: 5px;
+            }
+            QComboBox {
+                background-color: #424242;
+                color: white;
+                border: 1px solid #666;
+                border-radius: 3px;
+                padding: 5px 10px;
+                font-size: 14px;
+                min-width: 100px;
+            }
+            QComboBox::drop-down {
+                border: none;
+            }
+            QComboBox::down-arrow {
+                image: none;
+                border-left: 5px solid transparent;
+                border-right: 5px solid transparent;
+                border-top: 5px solid white;
+                margin-right: 5px;
+            }
+            QComboBox QAbstractItemView {
+                background-color: #424242;
+                color: white;
+                selection-background-color: #2196F3;
+            }
+            """
+        )
+
+        layout = QHBoxLayout(panel)
+        layout.setContentsMargins(20, 10, 20, 10)
+        layout.setSpacing(20)
+
+        # Start button
+        self.start_button = QPushButton("Start Slideshow")
+        self.start_button.clicked.connect(self._start_slideshow)
+        self.start_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.start_button.setFixedHeight(40)
+        layout.addWidget(self.start_button)
+
+        # Spacer
+        layout.addStretch()
+
+        # View mode selector
+        mode_label = QLabel("View Mode:")
+        self.ordered_radio = QRadioButton("Ordered")
+        self.random_radio = QRadioButton("Random")
+        self.ordered_radio.setChecked(True)
+
+        self.mode_button_group = QButtonGroup()
+        self.mode_button_group.addButton(self.ordered_radio)
+        self.mode_button_group.addButton(self.random_radio)
+
+        layout.addWidget(mode_label)
+        layout.addWidget(self.ordered_radio)
+        layout.addWidget(self.random_radio)
+
+        # Spacer
+        layout.addStretch()
+
+        # Timing selector
+        timing_label = QLabel("Image Duration:")
+        self.timing_combo = QComboBox()
+        self.timing_combo.addItems(
+            ["3 seconds", "5 seconds", "10 seconds", "15 seconds", "30 seconds"]
+        )
+        self.timing_combo.setCurrentIndex(1)  # Default to 5 seconds
+
+        layout.addWidget(timing_label)
+        layout.addWidget(self.timing_combo)
+
+        return panel
+
+    def set_media_list(
+        self, media_list: List[Media], current_media: Optional[Media] = None
+    ):
+        """Set the media list and optionally select a starting media item."""
+        self.media_list = media_list
+
+        if not media_list:
+            return
+
+        # Find starting index
+        if current_media:
+            try:
+                self.current_index = next(
+                    i
+                    for i, m in enumerate(media_list)
+                    if m.file_path == current_media.file_path
+                )
+            except StopIteration:
+                self.current_index = 0
+        else:
+            self.current_index = 0
+
+        # Display initial media
+        self._display_current_media()
+
+    def _start_slideshow(self):
+        """Start the slideshow."""
+        if not self.media_list:
+            return
+
+        self.is_running = True
+        self.is_paused = False
+
+        # Get selected mode
+        if self.random_radio.isChecked():
+            self.view_mode = "random"
+            self._create_shuffle()
+        else:
+            self.view_mode = "ordered"
+
+        # Get timing
+        timing_text = self.timing_combo.currentText()
+        seconds = int(timing_text.split()[0])
+        self.slide_duration = seconds * 1000
+
+        # Hide setup panel
+        self.setup_panel.hide()
+
+        # Set focus to main window to ensure key events are received
+        self.setFocus()
+
+        # Hide UI and cursor initially
+        self._hide_ui()
+
+        # Restart displaying media (to start video playback if on video)
+        self._display_current_media()
+
+    def _create_shuffle(self):
+        """Create a shuffled list of indices for random mode."""
+        self.shuffled_indices = list(range(len(self.media_list)))
+        random.shuffle(self.shuffled_indices)
+
+        # Find current position in shuffle
+        try:
+            self.shuffle_position = self.shuffled_indices.index(self.current_index)
+        except ValueError:
+            self.shuffle_position = 0
+            self.current_index = self.shuffled_indices[0]
+
+    def _cleanup_video_player(self):
+        """Clean up and remove the current video player."""
+        if self.video_player is not None:
+            try:
+                # Stop playback
+                self.video_player.stop()
+                # Process events to allow Qt cleanup
+                QCoreApplication.processEvents()
+                # Remove from stacked widget
+                if self.video_player_index >= 0:
+                    widget = self.stacked_widget.widget(self.video_player_index)
+                    if widget is not None:
+                        self.stacked_widget.removeWidget(widget)
+                # Delete the widget
+                self.video_player.deleteLater()
+                self.video_player = None
+                self.video_player_index = -1
+                # Process events again after deletion
+                QCoreApplication.processEvents()
+            except Exception as e:
+                print(f"Error cleaning up video player: {e}")
+
+    def _create_video_player(self):
+        """Create a fresh video player instance."""
+        try:
+            # Clean up any existing video player first
+            self._cleanup_video_player()
+
+            # Create new video player
+            self.video_player = VideoPlayer(db_manager=self.db_manager)
+            self.video_player_index = self.stacked_widget.addWidget(self.video_player)
+        except Exception as e:
+            print(f"Error creating video player: {e}")
+
+    def _display_current_media(self):
+        """Display the current media item."""
+        if not self.media_list or self.current_index >= len(self.media_list):
+            return
+
+        current_media = self.media_list[self.current_index]
+
+        # Stop any existing timer
+        self.advance_timer.stop()
+
+        # Determine if video or image
+        is_video = current_media.file_path.suffix.lower() in [
+            ".mp4",
+            ".avi",
+            ".mov",
+            ".mkv",
+            ".webm",
+            ".m4v",
+        ]
+
+        if is_video:
+            # Only create a new video player if we don't have one
+            # This avoids the flash when navigating between videos
+            if self.video_player is None:
+                self._create_video_player()
+                if self.video_player is None:
+                    return
+            else:
+                # Stop the current video before loading new one
+                try:
+                    self.video_player.stop()
+                except Exception:
+                    pass
+
+            # Show video player
+            self.stacked_widget.setCurrentWidget(self.video_player)
+
+            try:
+                success = self.video_player.load_video(
+                    current_media.file_path, current_media
+                )
+                if success and self.is_running:
+                    self.video_player.play()
+            except Exception as e:
+                print(f"Error loading/playing video: {e}")
+            # No auto-advance for videos
+        else:
+            # If there's a video player, clean it up when switching to image
+            if self.video_player is not None:
+                self._cleanup_video_player()
+
+            # Show image viewer
+            self.stacked_widget.setCurrentWidget(self.image_viewer)
+            try:
+                self.image_viewer.load_image(str(current_media.file_path))
+            except Exception as e:
+                print(f"Error loading image: {e}")
+
+            # Start auto-advance timer if slideshow is running and not paused
+            if self.is_running and not self.is_paused:
+                self.advance_timer.start(self.slide_duration)
+
+        # Emit signal
+        self.media_changed.emit(current_media)
+
+    def _advance_to_next(self):
+        """Advance to the next media item."""
+        self.navigate_next()
+
+    def navigate_next(self):
+        """Navigate to the next media item."""
+        if not self.media_list:
+            return
+
+        if self.view_mode == "random":
+            self.shuffle_position += 1
+            if self.shuffle_position >= len(self.shuffled_indices):
+                # Re-shuffle and start over
+                self._create_shuffle()
+                self.shuffle_position = 0
+            self.current_index = self.shuffled_indices[self.shuffle_position]
+        else:
+            # Ordered mode
+            self.current_index = (self.current_index + 1) % len(self.media_list)
+
+        self._display_current_media()
+
+    def navigate_previous(self):
+        """Navigate to the previous media item."""
+        if not self.media_list:
+            return
+
+        if self.view_mode == "random":
+            self.shuffle_position -= 1
+            if self.shuffle_position < 0:
+                self.shuffle_position = len(self.shuffled_indices) - 1
+            self.current_index = self.shuffled_indices[self.shuffle_position]
+        else:
+            # Ordered mode
+            self.current_index = (self.current_index - 1) % len(self.media_list)
+
+        self._display_current_media()
+
+    def toggle_pause(self):
+        """Toggle pause state of slideshow."""
+        if not self.is_running:
+            return
+
+        self.is_paused = not self.is_paused
+
+        if self.is_paused:
+            self.advance_timer.stop()
+        else:
+            # Resume timer if on an image
+            current_media = self.media_list[self.current_index]
+            is_video = current_media.file_path.suffix.lower() in [
+                ".mp4",
+                ".avi",
+                ".mov",
+                ".mkv",
+                ".webm",
+                ".m4v",
+            ]
+            if not is_video:
+                self.advance_timer.start(self.slide_duration)
+
+    def _show_ui(self):
+        """Show UI elements."""
+        if not self.is_running:
+            return
+
+        # Show video controls if on video
+        if (
+            self.video_player is not None
+            and self.stacked_widget.currentWidget() == self.video_player
+        ):
+            self.video_player.control_widget.show()
+
+        # Show cursor
+        self.setCursor(Qt.CursorShape.ArrowCursor)
+
+        # Start hide timer
+        self.ui_hide_timer.start(3000)  # 3 seconds
+
+    def _hide_ui(self):
+        """Hide UI elements."""
+        if not self.is_running:
+            return
+
+        # Hide video controls
+        if (
+            self.video_player is not None
+            and self.stacked_widget.currentWidget() == self.video_player
+        ):
+            self.video_player.control_widget.hide()
+
+        # Hide cursor
+        self.setCursor(Qt.CursorShape.BlankCursor)
+
+    def showEvent(self, event) -> None:
+        """Handle window show event."""
+        super().showEvent(event)
+        # Set focus to main window to receive key events
+        self.setFocus()
+        # Ensure setup panel is visible when window opens (if slideshow not running)
+        if not self.is_running:
+            self.setup_panel.show()
+            # Show cursor when browsing (setup panel visible)
+            self.setCursor(Qt.CursorShape.ArrowCursor)
+
+    def mouseMoveEvent(self, event: Optional[QMouseEvent]) -> None:
+        """Handle mouse movement to show/hide UI."""
+        if self.is_running:
+            self._show_ui()
+        super().mouseMoveEvent(event)
+
+    def keyPressEvent(self, event: Optional[QKeyEvent]) -> None:
+        """Handle keyboard shortcuts."""
+        if event is None:
+            return
+        key = event.key()
+
+        if key == Qt.Key.Key_Escape:
+            self.close()
+        elif key == Qt.Key.Key_Space:
+            if self.is_running:
+                # Toggle pause
+                self.toggle_pause()
+                # Also toggle video playback if on video
+                if (
+                    self.video_player is not None
+                    and self.stacked_widget.currentWidget() == self.video_player
+                ):
+                    self.video_player.toggle_playback()
+        elif key == Qt.Key.Key_Left:
+            self.navigate_previous()
+        elif key == Qt.Key.Key_Right:
+            self.navigate_next()
+        elif key == Qt.Key.Key_F:
+            self._toggle_favorite()
+        elif key == Qt.Key.Key_M:
+            if (
+                self.video_player is not None
+                and self.stacked_widget.currentWidget() == self.video_player
+            ):
+                self.video_player.toggle_mute()
+        elif key == Qt.Key.Key_Up:
+            if (
+                self.video_player is not None
+                and self.stacked_widget.currentWidget() == self.video_player
+            ):
+                current_volume = self.video_player.volume_slider.value()
+                self.video_player.volume_slider.setValue(min(100, current_volume + 5))
+        elif key == Qt.Key.Key_Down:
+            if (
+                self.video_player is not None
+                and self.stacked_widget.currentWidget() == self.video_player
+            ):
+                current_volume = self.video_player.volume_slider.value()
+                self.video_player.volume_slider.setValue(max(0, current_volume - 5))
+        else:
+            super().keyPressEvent(event)
+
+    def _toggle_favorite(self):
+        """Toggle favorite status of current media."""
+        if not self.media_list or self.current_index >= len(self.media_list):
+            return
+
+        current_media = self.media_list[self.current_index]
+        new_status = not current_media.is_favorite
+        current_media.is_favorite = new_status
+        self.db_manager.set_favorite(current_media.file_path, new_status)
+        # Emit the Media object, not just the file_path (matches MediaViewer behavior)
+        self.favorite_toggled.emit(current_media, new_status)
+
+    def closeEvent(self, event: Optional[QCloseEvent]) -> None:
+        """Handle window close event."""
+        # Stop timers
+        self.advance_timer.stop()
+        self.ui_hide_timer.stop()
+
+        # Clean up video player if it exists
+        self._cleanup_video_player()
+
+        # Reset state
+        self.is_running = False
+        self.is_paused = False
+
+        # Show setup panel and cursor for next time
+        self.setup_panel.show()
+        self.setCursor(Qt.CursorShape.ArrowCursor)
+
+        # Emit closed signal
+        self.closed.emit()
+
+        super().closeEvent(event)

--- a/metascan/ui/virtual_thumbnail_view.py
+++ b/metascan/ui/virtual_thumbnail_view.py
@@ -966,14 +966,12 @@ class VirtualScrollArea(QScrollArea):
             new_index = media_count - 1
         elif key == Qt.Key.Key_PageUp:
             visible_rows = (
-                self.viewport_info.visible_height
-                // self.layout_metrics.cell_height
+                self.viewport_info.visible_height // self.layout_metrics.cell_height
             )
             new_index = max(0, current_index - (visible_rows * columns))
         elif key == Qt.Key.Key_PageDown:
             visible_rows = (
-                self.viewport_info.visible_height
-                // self.layout_metrics.cell_height
+                self.viewport_info.visible_height // self.layout_metrics.cell_height
             )
             new_index = min(media_count - 1, current_index + (visible_rows * columns))
         else:

--- a/metascan/ui/virtual_thumbnail_view.py
+++ b/metascan/ui/virtual_thumbnail_view.py
@@ -931,6 +931,58 @@ class VirtualScrollArea(QScrollArea):
 
         event.accept()
 
+    def keyPressEvent(self, event) -> None:
+        """Handle keyboard navigation."""
+        if not self.filtered_media:
+            return super().keyPressEvent(event)
+
+        current_index = self.selected_index
+        media_count = len(self.filtered_media)
+        columns = self.layout_metrics.columns
+
+        # Initialize selection if none exists
+        if current_index == -1 and media_count > 0:
+            self.select_by_index(0)
+            return
+
+        key = event.key()
+        new_index = current_index
+
+        if key == Qt.Key.Key_Left:
+            if current_index > 0:
+                new_index = current_index - 1
+        elif key == Qt.Key.Key_Right:
+            if current_index < media_count - 1:
+                new_index = current_index + 1
+        elif key == Qt.Key.Key_Up:
+            if current_index >= columns:
+                new_index = current_index - columns
+        elif key == Qt.Key.Key_Down:
+            if current_index + columns < media_count:
+                new_index = current_index + columns
+        elif key == Qt.Key.Key_Home:
+            new_index = 0
+        elif key == Qt.Key.Key_End:
+            new_index = media_count - 1
+        elif key == Qt.Key.Key_PageUp:
+            visible_rows = (
+                self.viewport_info.visible_height
+                // self.layout_metrics.cell_height
+            )
+            new_index = max(0, current_index - (visible_rows * columns))
+        elif key == Qt.Key.Key_PageDown:
+            visible_rows = (
+                self.viewport_info.visible_height
+                // self.layout_metrics.cell_height
+            )
+            new_index = min(media_count - 1, current_index + (visible_rows * columns))
+        else:
+            return super().keyPressEvent(event)
+
+        if new_index != current_index and 0 <= new_index < media_count:
+            self.select_by_index(new_index)
+            event.accept()
+
 
 class VirtualThumbnailView(QWidget):
     """
@@ -1208,6 +1260,8 @@ class VirtualThumbnailView(QWidget):
         """Handle item selection."""
         logger.debug(f"Item clicked: {media.file_name}")
         self.selected_media = media
+        # Set focus to enable keyboard navigation
+        self.setFocus()
 
     def _on_selection_changed(self, media: Media) -> None:
         """Handle selection change."""
@@ -1303,55 +1357,9 @@ class VirtualThumbnailView(QWidget):
             raise RuntimeError(f"Unexpected error opening file: {e}")
 
     def keyPressEvent(self, event) -> None:
-        """Handle keyboard navigation."""
-        if not self.scroll_area.filtered_media:
-            return super().keyPressEvent(event)
-
-        current_index = self.scroll_area.selected_index
-        media_count = len(self.scroll_area.filtered_media)
-        columns = self.scroll_area.layout_metrics.columns
-
-        # Initialize selection if none exists
-        if current_index == -1 and media_count > 0:
-            self.scroll_area.select_by_index(0)
-            return
-
-        key = event.key()
-        new_index = current_index
-
-        if key == Qt.Key.Key_Left:
-            if current_index > 0:
-                new_index = current_index - 1
-        elif key == Qt.Key.Key_Right:
-            if current_index < media_count - 1:
-                new_index = current_index + 1
-        elif key == Qt.Key.Key_Up:
-            if current_index >= columns:
-                new_index = current_index - columns
-        elif key == Qt.Key.Key_Down:
-            if current_index + columns < media_count:
-                new_index = current_index + columns
-        elif key == Qt.Key.Key_Home:
-            new_index = 0
-        elif key == Qt.Key.Key_End:
-            new_index = media_count - 1
-        elif key == Qt.Key.Key_PageUp:
-            visible_rows = (
-                self.scroll_area.viewport_info.visible_height
-                // self.scroll_area.layout_metrics.cell_height
-            )
-            new_index = max(0, current_index - (visible_rows * columns))
-        elif key == Qt.Key.Key_PageDown:
-            visible_rows = (
-                self.scroll_area.viewport_info.visible_height
-                // self.scroll_area.layout_metrics.cell_height
-            )
-            new_index = min(media_count - 1, current_index + (visible_rows * columns))
-        else:
-            return super().keyPressEvent(event)
-
-        if new_index != current_index and 0 <= new_index < media_count:
-            self.scroll_area.select_by_index(new_index)
+        """Handle keyboard navigation by delegating to scroll area."""
+        # Delegate to the scroll area's keyPressEvent handler
+        self.scroll_area.keyPressEvent(event)
 
     def get_selected_media(self) -> Optional[Media]:
         """Get the currently selected media object."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 # Metascan Production Dependencies
+# Python Version Requirement
+python_requires>=3.11,<3.13
+
 # Core UI Framework
 PyQt6==6.6.1
 PyQt6-Qt6==6.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 # Metascan Production Dependencies
-# Python Version Requirement
-python_requires>=3.11,<3.13
-
 # Core UI Framework
 PyQt6==6.6.1
 PyQt6-Qt6==6.6.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author="Metascan",
     packages=find_packages(),
     install_requires=requirements,
-    python_requires=">=3.8",
+    python_requires=">=3.11,<3.13",
     entry_points={
         "console_scripts": [
             "metascan=metascan.ui.main_window:main",


### PR DESCRIPTION
### New Features

## Slideshow
 - New Slideshow feature
 - Runs automatically, or supports cursor control
 - Videos play automatically
 - Support None, Fade, Crossfade, Slide transition options

## Volume Control
  - Volume slider with real-time adjustment (0-100%)
  - Mute button 
  - Keyboard shortcuts: ↑/↓ to adjust volume, M to toggle mute

## Playback Speed Control
  - UI dropdown selector with preset speeds: 0.25x, 0.5x, 0.75x, 1x, 1.25x, 1.5x, 2x
  - Per-file speed persistence - each video remembers its playback speed in the database
  - Automatically snaps invalid speeds to nearest available option
  - Falls back to global default from config.json for videos without custom speeds

## Frame-by-Frame Navigation
  - Previous/Next frame buttons (◀◀ / ▶▶) in the control bar
  - Keyboard shortcuts: , (comma) for previous frame, . (period) for next frame
  - Approximately 33ms steps (~1 frame at 30fps)
  - Automatically pauses playback for precise frame stepping

  Keyboard Shortcuts Help

  - Help overlay (press H or ?) displays all available keyboard shortcuts
  - Shows for 5 seconds with formatted shortcut list

##  Bug Fixes
  - Fixed playback speed dropdown not updating when switching between videos
  - Fixed playback speed changes being ignored when video is paused
  - Fixed playback speed not persisting after app restart
  - Fixed video looping issues: Progress bar now resets correctly and frame navigation works reliably after video loops
  - Switched from Qt's built-in infinite loop to manual loop control for better position tracking

##  Database Changes
  - Added playback_speed column to media table (nullable REAL field)
  - Automatically migrates existing databases on startup
  - New methods: load_playback_speed() and update_playback_speed()

## UI Improvements
  - Reduced internal padding on speed dropdown and mute button for better icon visibility
  - All controls include tooltips showing keyboard shortcuts
  - Control bar now displays: frame nav, play/pause, timeline, time display, speed, volume, and help

  ---
##  Keyboard Shortcuts Quick Reference:

```
  - Space: Play/Pause
  - , / . : Previous/Next Frame
  - ↑ / ↓: Volume Up/Down
  - M: Mute
  - ← / →: Previous/Next Media
  - F: Toggle Favorite
  - Ctrl+D: Delete
  - H or ?: Show Shortcuts
  - Esc: Close Viewer
 ```
